### PR TITLE
Incorporate Annotations to GWASDataLoader

### DIFF
--- a/GWASDataLoader.py
+++ b/GWASDataLoader.py
@@ -147,7 +147,7 @@ class GWASDataLoader(object):
         
         # ------- Functional annotation data -------
         self.annotations = None
-        self.num_annotations = None
+        self.C = None
         self.annotation_names = None
         self.annotation_snp_order = None
 
@@ -456,21 +456,17 @@ class GWASDataLoader(object):
             try:
                 # read annotation file
                 annot_df = pd.read_csv(annot_file, sep="\t")
-                # assuming chromosome information is available in the annotation file name
-                # which has the following suffix: .[chromosome].annot
-                # e.g., .22.annot suffix for chromosome 22
-                # TODO improve this for more general cases
-                c = int(annot_file.split(".")[-2])
             except Exception as e:
                 self.annotations = None
                 raise e
 
+            c = annot_df["CHR"][0]
             annot_df = annot_df.set_index('SNP')
             annot_df = annot_df.drop(['CHR', 'BP', 'CM', 'base'], axis=1)
             annot_df = annot_df.loc[self.snps[c]]
 
             if i == 0:
-                self.num_annotations = len(annot_df.columns)
+                self.C = len(annot_df.columns)
                 self.annotation_names = np.array(annot_df.columns)
             
             self.annotations[c] = np.array(annot_df.values)

--- a/GWASSimulator.py
+++ b/GWASSimulator.py
@@ -111,8 +111,8 @@ class GWASSimulator(GWASDataLoader):
         Simulate annotation weights, which would influence the variance in causal effect size
         :return:
         """
-        if self.num_annotations is not None:
-            self.annotation_weights = np.random.normal(scale=1./self.M, size=self.num_annotations)
+        if self.C is not None:
+            self.annotation_weights = np.random.normal(scale=1./self.M, size=self.C)
 
     def simulate_phenotypes(self):
         """

--- a/GWASSimulator.py
+++ b/GWASSimulator.py
@@ -111,8 +111,8 @@ class GWASSimulator(GWASDataLoader):
         Simulate annotation weights, which would influence the variance in causal effect size
         :return:
         """
-        if self.C is not None:
-            self.annotation_weights = np.random.normal(scale=1./self.M, size=self.C)
+        if self.num_annotations is not None:
+            self.annotation_weights = np.random.normal(scale=1./self.M, size=self.num_annotations)
 
     def simulate_phenotypes(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ ext_modules = cythonize([
     Extension("c_utils",
               ["c_utils.pyx"],
               libraries=["m"],
-              extra_compile_args=["-ffast-math", "-fopenmp"]
+              extra_compile_args=["-ffast-math", "-fopenmp"],
+              extra_link_args=["-fopenmp"],
               ),
     Extension("LDWrapper",
               ["LDWrapper.pyx"],


### PR DESCRIPTION
The change in setup.py is for dynamic of linking openmp library, which was required for the build on Ubuntu to succeed. This version was tested and the GWASSimulator.simulate() function did not break 