### PR TITLE
Update sumstats_parsers.py to better handle summary statistics with NA

### DIFF
--- a/magenpy/parsers/sumstats_parsers.py
+++ b/magenpy/parsers/sumstats_parsers.py
@@ -65,13 +65,13 @@ class SumstatsParser(object):
         if self.col_name_converter is not None:
             df.rename(columns=self.col_name_converter, inplace=True)
 
-        magenpy_cols = {'CHR', 'SNP', 'POS', 'A1', 'A2', 'REF', 'ALT', 'ALT1',
-                      'MAF', 'N', 'BETA', 'SE', 'Z', 'PVAL', 'MAC'}
-        cols_to_keep = [c for c in df.columns if c in magenpy_cols]
-        df = df[cols_to_keep]
-
         if drop_na:
-            df = df.dropna()
+            subset = (
+                [c for c in self.col_name_converter.values() if c in df.columns]
+                if self.col_name_converter is not None
+                else None
+            )
+            df = df.dropna(subset=subset)
 
         try:
             df['POS'] = df['POS'].astype(np.int32)

--- a/magenpy/parsers/sumstats_parsers.py
+++ b/magenpy/parsers/sumstats_parsers.py
@@ -62,11 +62,16 @@ class SumstatsParser(object):
 
         df = pd.read_csv(file_name, **self.read_csv_kwargs)
 
-        if drop_na:
-            df = df.dropna()
-
         if self.col_name_converter is not None:
             df.rename(columns=self.col_name_converter, inplace=True)
+
+        magenpy_cols = {'CHR', 'SNP', 'POS', 'A1', 'A2', 'REF', 'ALT', 'ALT1',
+                      'MAF', 'N', 'BETA', 'SE', 'Z', 'PVAL', 'MAC'}
+        cols_to_keep = [c for c in df.columns if c in magenpy_cols]
+        df = df[cols_to_keep]
+
+        if drop_na:
+            df = df.dropna()
 
         try:
             df['POS'] = df['POS'].astype(np.int32)


### PR DESCRIPTION
Currently a bug where GWASCatalog summary statistics (though parser bug could extend to any format) that contain unused/empty columns with NA values (e.g., ci_upper and ci_lower which are standard in GWASCatalog harmonization) will silently drop all rows.  The consequence is that summary statistics used for packages like VIPRS must not have any unused columns for it to work, else there is an unspecific error that is hard to trace. I suggest subsetting to magenpy columns before the drop_na